### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,3 @@
+[![Board Status](https://dev.azure.com/kavitatengse/f3b26875-f76b-4f5e-be98-2f0717440056/b5019124-2b95-4f41-ae40-3114814b7790/_apis/work/boardbadge/995327ee-c1c7-4203-9c12-cd78f24501d9)](https://dev.azure.com/kavitatengse/f3b26875-f76b-4f5e-be98-2f0717440056/_boards/board/t/b5019124-2b95-4f41-ae40-3114814b7790/Microsoft.RequirementCategory)
 # Sample.NetCoreApi
 Sample.NetCoreApiSample.NetCoreApiSample.NetCoreApiSample.NetCoreApiSample.NetCoreApi


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#1](https://dev.azure.com/kavitatengse/f3b26875-f76b-4f5e-be98-2f0717440056/_workitems/edit/1). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.